### PR TITLE
Fixed config overwrite and update version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -149,7 +149,7 @@ dependencies {
     // If the group id is "net.minecraft" and the artifact id is one of ["client", "server", "joined"],
     // then special handling is done to allow a setup of a vanilla dependency without the use of an external repository.
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
-    implementation files('libs/trueuuid-1.0.2.jar')
+    implementation files('libs/trueuuid-1.0.5.jar')
     // Example mod dependency with JEI - using fg.deobf() ensures the dependency is remapped to your development mappings
     // The JEI API is declared for compile time use, while the full JEI artifact is used at runtime
     // compileOnly fg.deobf("mezz.jei:jei-${mc_version}-common-api:${jei_version}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,7 +38,7 @@ mod_name=OfflineAuth
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=GNU LGPL 3.0
 # The mod version. See https://semver.org/
-mod_version=1.0.1
+mod_version=1.0.3
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/cn/alini/offlineauth/OfflineAuthHandler.java
+++ b/src/main/java/cn/alini/offlineauth/OfflineAuthHandler.java
@@ -44,7 +44,7 @@ public class OfflineAuthHandler {
     private static final Gson gson = new Gson();
     private static final Map<String, AutoLoginInfo> autoLoginMap = new HashMap<>();
     private static final Map<String, FailInfo> failMap = new HashMap<>();
-    static { loadAutoLogin(); loadFail(); }
+    static { config.load(); loadAutoLogin(); loadFail(); }
 
     private static boolean isOfflinePlayer(ServerPlayer player) {
         return !TrueuuidApi.isPremium(player.getName().getString().toLowerCase(Locale.ROOT));

--- a/src/main/java/cn/alini/offlineauth/Offlineauth.java
+++ b/src/main/java/cn/alini/offlineauth/Offlineauth.java
@@ -13,6 +13,5 @@ public class Offlineauth {
     public Offlineauth() {
         //mod成功加载日志
         LOGGER.info("OfflineAuth mod loaded successfully!");
-        new AuthConfig().save();
     }
 }


### PR DESCRIPTION
This PR fixes the `config.json` from being overwritten with defaults on every start of the mod. Now it properly loads the config if it exists. I also updated the trueuuid dependency to v1.0.5 and incremented the mod version to 1.0.3.
**NOTE**: This functionality already seems to have been implemented in [v1.0.3 that is uploaded on Modrinth here](https://modrinth.com/mod/offlineauth/version/1.0.3), so not sure if something hasn't been committed or what... I say this as using that 1.0.3 version, I had no problems modifying the config, but now, compiling my own version of the mod, I was running into this issue.

---
## AI Overview Below:

> This pull request introduces a few minor changes to the `OfflineAuth` mod, focusing on configuration loading and versioning. The main update is ensuring that the mod configuration is loaded at class initialization, and the mod version is incremented.
> 
> Configuration improvements:
> 
> * [`OfflineAuthHandler.java`](diffhunk://#diff-250d4e94972c7adee5bcef759acd99a554d2fc88475a1fb2a17a3ac82b3b7bb3L47-R47): The static initializer now calls `config.load()` before loading auto-login and failure information, ensuring configuration is loaded as soon as the class is initialized.
> * [`Offlineauth.java`](diffhunk://#diff-1bb02cb978fe1de3580c2ee905a9ead43d834e23d798ca0471ad162be3b0339cL16): Removed the call to `new AuthConfig().save();` from the constructor, as configuration saving is no longer needed at this point.
> 
> Version update:
> 
> * [`gradle.properties`](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L41-R41): Updated `mod_version` from `1.0.1` to `1.0.3` to reflect the latest changes.