### PR TITLE
Add Reload Config command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Supports registration, login, inventory protection, brute-force prevention, and 
 - `/login <password>` — Login to your account.
 - `/changepassword <old> <new>` — Change your password.
 - `/auth help` — Show help information.
+- `/auth reload` — Reload the configuration file (requires permission level 2).
 
 ## Configuration
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -22,6 +22,7 @@
 - `/login <密码>` — 登录账户
 - `/changepassword <旧密码> <新密码>` — 修改密码
 - `/auth help` — 查看帮助信息
+- `/auth reload` — 重载配置文件（需要权限等级 2）
 
 ## 配置说明
 

--- a/build.gradle
+++ b/build.gradle
@@ -149,7 +149,7 @@ dependencies {
     // If the group id is "net.minecraft" and the artifact id is one of ["client", "server", "joined"],
     // then special handling is done to allow a setup of a vanilla dependency without the use of an external repository.
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
-    implementation files('libs/trueuuid-1.0.2.jar')
+    implementation files('libs/trueuuid-1.0.5.jar')
     // Example mod dependency with JEI - using fg.deobf() ensures the dependency is remapped to your development mappings
     // The JEI API is declared for compile time use, while the full JEI artifact is used at runtime
     // compileOnly fg.deobf("mezz.jei:jei-${mc_version}-common-api:${jei_version}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,7 +38,7 @@ mod_name=OfflineAuth
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=GNU LGPL 3.0
 # The mod version. See https://semver.org/
-mod_version=1.0.3
+mod_version=1.0.4
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,7 +38,7 @@ mod_name=OfflineAuth
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=GNU LGPL 3.0
 # The mod version. See https://semver.org/
-mod_version=1.0.1
+mod_version=1.0.3
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/cn/alini/offlineauth/AuthConfig.java
+++ b/src/main/java/cn/alini/offlineauth/AuthConfig.java
@@ -55,6 +55,7 @@ public class AuthConfig {
         messages.put("help_login", "§e/login 密码 §7- 登录账户");
         messages.put("help_changepwd", "§e/changepassword 旧密码 新密码 §7- 修改密码");
         messages.put("auto_login_warn", "§e⚠已启用自动登录（同IP设备短时间内无需重复登录）。如在网吧/公共电脑请勿使用此功能，避免账号被盗。");
+        messages.put("reload_success", "§a配置已重载！");
 
         // 正确做法：在构造后，手动调用 load()，不要在构造里调用
         // 由主类 new AuthConfig 后，再调用 config.load()

--- a/src/main/java/cn/alini/offlineauth/OfflineAuthHandler.java
+++ b/src/main/java/cn/alini/offlineauth/OfflineAuthHandler.java
@@ -546,6 +546,14 @@ public class OfflineAuthHandler {
                                     return 1;
                                 })
                         )
+                        .then(Commands.literal("reload")
+                                .requires(source -> source.hasPermission(2))
+                                .executes(ctx -> {
+                                    config.load();
+                                    ctx.getSource().sendSuccess(() -> Component.literal(config.msg("reload_success")), true);
+                                    return 1;
+                                })
+                        )
         );
     }
 }

--- a/src/main/java/cn/alini/offlineauth/OfflineAuthHandler.java
+++ b/src/main/java/cn/alini/offlineauth/OfflineAuthHandler.java
@@ -44,7 +44,7 @@ public class OfflineAuthHandler {
     private static final Gson gson = new Gson();
     private static final Map<String, AutoLoginInfo> autoLoginMap = new HashMap<>();
     private static final Map<String, FailInfo> failMap = new HashMap<>();
-    static { loadAutoLogin(); loadFail(); }
+    static { config.load(); loadAutoLogin(); loadFail(); }
 
     private static boolean isOfflinePlayer(ServerPlayer player) {
         return !TrueuuidApi.isPremium(player.getName().getString().toLowerCase(Locale.ROOT));

--- a/src/main/java/cn/alini/offlineauth/Offlineauth.java
+++ b/src/main/java/cn/alini/offlineauth/Offlineauth.java
@@ -13,6 +13,5 @@ public class Offlineauth {
     public Offlineauth() {
         //mod成功加载日志
         LOGGER.info("OfflineAuth mod loaded successfully!");
-        new AuthConfig().save();
     }
 }


### PR DESCRIPTION
This PR simply adds an `/auth reload` command to the mod, which allows you to reload the `config.json` file while running. This makes config changes far easier to test without needing to reboot the server.


---
## AI Overview Below:

> This pull request introduces a new `/auth reload` command to allow reloading the mod configuration at runtime, updates the mod version, and improves initialization. The most significant changes are grouped below:
> 
> **Feature Addition: Runtime Configuration Reload**
> 
> * Added a `/auth reload` command (permission level 2 required) that reloads the configuration and provides a success message to the user.
> * Added a new localized message `reload_success` for feedback after reloading the configuration.
> 
> **Initialization & Configuration Handling**
> 
> * Changed static initialization in `OfflineAuthHandler` to explicitly load the configuration (`config.load()`) during class loading, ensuring configuration is available before other static initializations.
> * Removed unnecessary call to `AuthConfig.save()` in the mod's main class constructor, streamlining startup.
> 
> **Version Update**
> 
> * Updated the mod version in `gradle.properties` from `1.0.1` to `1.0.4`.